### PR TITLE
Set javascript Content-Type for getTranslatedJSLabels return string

### DIFF
--- a/collective/documentviewer/views.py
+++ b/collective/documentviewer/views.py
@@ -348,6 +348,10 @@ if(hash.search("\#(document|pages|text)\/") != -1 || (%(fullscreen)s &&
         dv_translated_label_on_page = dv_translated_label_on_page.replace("'", "\\'")
         dv_translated_label_for_page = dv_translated_label_for_page.replace("'", "\\'")
 
+        self.request.response.setHeader('Content-Type',
+                                        'application/x-javascript;;charset="utf-8"')
+
+
         return TEMPLATE % dict(
             dv_translated_label_zoom=dv_translated_label_zoom,
             dv_translated_label_page=dv_translated_label_page,


### PR DESCRIPTION
Javascript translation strings are defined in method getTranslatedJSLabels and returned as a string. The Content-Type header must be set to application/x-javascript or it defaults to text/plain, and the javascript resource is -- correctly -- rejected by modern security conscious browsers.

Encountered with Plone 4.3 and recent Chrome browser (Version 39.0.2171.95, 64-bit).

Not 100% sure if I should be setting charset="utf-8" but a discussion between David Glick and Martin Aspeli on Stack Overflow seemed to suggest that this is the most robust approach. (See http://plone.293351.n2.nabble.com/Setting-a-mime-type-on-a-Zope-3-browser-view-td4442770.html)