### PR TITLE
Seems asyncmonitor has moved and this config needs updating. Server c…

### DIFF
--- a/collective/documentviewer/browser/configure.zcml
+++ b/collective/documentviewer/browser/configure.zcml
@@ -36,7 +36,7 @@
     zcml:condition="installed plone.app.async"
     name="dv-remove-from-queue"
     for="Products.CMFPlone.interfaces.IPloneSiteRoot"
-    class=".views.AsyncMonitor"
+    class=".controlpanel.AsyncMonitor"
     attribute="remove"
     permission="cmf.ManagePortal"
     layer="..interfaces.ILayer" />


### PR DESCRIPTION
…omplains otherwise about ConfigurationError: ('Invalid value for', 'class', 'ImportError: Module collective.documentviewer.browser.views has no global AsyncMonitor')

But please check if I didn't overlook something…