### PR TITLE
handle iso codes correctly

### DIFF
--- a/collective/documentviewer/iso639_2_utf8.py
+++ b/collective/documentviewer/iso639_2_utf8.py
@@ -20,7 +20,10 @@ def getisocodes_dict(data_path):
     for line in fp:
         fields = line.split('|')
         if len(fields[2]) > 0:
-            map[fields[2]] = fields[0]
+            if len(fields[1]) > 0:
+                map[fields[2]] = fields[1]    
+            else:
+                map[fields[2]] = fields[0]
     fp.close()
     return map
 


### PR DESCRIPTION
German was Broken, French would also not work.

The right language code is in Column 1, but it was never used. Therefore you will get Errors from tesseract.

My fix will use Column 1 if it is present. This fixes german and french.

best regards