### PR TITLE
Support libreoffice under Nixos

### DIFF
--- a/collective/documentviewer/convert.py
+++ b/collective/documentviewer/convert.py
@@ -285,8 +285,12 @@ class DocSplitSubProcess(BaseSubProcess):
         # while using libreoffice, docsplit leaves a 'libreoffice'
         # folder next to the generated PDF, removes it!
         libreOfficePath = os.path.join(output_dir, 'libreoffice')
+        # In Nixos, the folder is called 'libreofficedev'
+        libreOfficePathNixos = os.path.join(output_dir, 'libreofficedev')
         if os.path.exists(libreOfficePath):
             shutil.rmtree(libreOfficePath)
+        elif os.path.exists(libreOfficePathNixos):
+            shutil.rmtree(libreOfficePathNixos)
 
         # move the file to the right location now
         files = set(os.listdir(output_dir))

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,8 +4,9 @@ Changelog
 4.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Added support for libreoffice under Nixos, which uses a different folder name
+  for its conversion directories
+  [pysailor]
 
 4.1.0 (2017-05-15)
 ------------------


### PR DESCRIPTION
On Nixos, libreoffice (5.X) apparently creates its temp-folders not under the name 'libreoffice', but 'libreofficedev'.
That means this fails: https://github.com/collective/collective.documentviewer/blob/master/collective/documentviewer/convert.py#L287
So an otherwise successful conversion gets aborted because the hard-coded `libreOfficePath` is wrong and the number of files is not equal.

Therefore, also check for the existence of the alternative folder and remove it if found.