### PR TITLE
Fixed problem breaking the front pages of DV pages providing ILeadImage

### DIFF
--- a/collective/documentviewer/convert.py
+++ b/collective/documentviewer/convert.py
@@ -454,9 +454,15 @@ class Converter(object):
                     filename = dump_filename
                     break
             filepath = os.path.join(path, filename)
-            fi = open(filepath)
+            tmppath = '%s.tmp' % (filepath)
+
+            # NamedBlobImage eventually calls blob.consume,
+            # destroying the image, so we need to make a temporary copy.
+            shutil.copyfile(filepath, tmppath)
+            fi = open(tmppath)
             self.context.image = NamedBlobImage(fi, filename=filename.decode('utf8'))
             fi.close()
+
 
         if self.gsettings.storage_type == 'Blob':
             logger.info('setting blob data for %s' % repr(context))

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,7 +2,7 @@ Changelog
 =========
 
 4.1.1 (unreleased)
-=======
+------------------
 
 - Fix issue breaking zoom on the 1st page of PDFs
   [obct537]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,7 +2,10 @@ Changelog
 =========
 
 4.1.1 (unreleased)
-------------------
+=======
+
+- Fix issue breaking zoom on the 1st page of PDFs
+  [obct537]
 
 - Add function and browser view (``convert_all_unconverted``) to convert all files, which haven't been converted yet.
   [thet]


### PR DESCRIPTION
The mechanism to automatically generate lead images on a document is removing the "large" image for the first page. If you follow the chain downward, NamedBlobImage is calling blob.consume:
https://github.com/plone/plone.namedfile/blob/master/plone/namedfile/storages.py#L61

When this happens, the zoomed-in version of the first page is missing, and just shows a blank page.
Since the file passed to the NamedBlobImage call is removed, I figure there's no harm in making a temporary copy of the image. I'm certainly open to other options as well.